### PR TITLE
v389 Add entrypoint for CREATE/DROP catalog

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -163,6 +163,17 @@ public class ConnectorManager
         connectors.clear();
     }
 
+    public synchronized void dropConnection(String catalogName)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+
+        catalogManager.removeCatalog(catalogName).ifPresent(catalog -> {
+            removeConnectorInternal(catalog);
+            removeConnectorInternal(createInformationSchemaCatalogName(catalog));
+            removeConnectorInternal(createSystemTablesCatalogName(catalog));
+        });
+    }
+
     public synchronized void addConnectorFactory(ConnectorFactory connectorFactory, Function<CatalogName, ClassLoader> duplicatePluginClassLoaderFactory)
     {
         requireNonNull(connectorFactory, "connectorFactory is null");

--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogResource.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogResource.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.inject.Inject;
+import io.trino.server.security.ResourceSecurity;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.util.Map;
+
+import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
+
+@Path("/v1/catalog")
+public class CatalogResource
+{
+    private final DynamicCatalogStore dynamicCatalogStore;
+
+    @Inject
+    public CatalogResource(DynamicCatalogStore dynamicCatalogStore)
+    {
+        this.dynamicCatalogStore = dynamicCatalogStore;
+    }
+
+    @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ResourceSecurity(PUBLIC)
+    public Response catalogList()
+    {
+        return Response.ok(dynamicCatalogStore.catalogList()).build();
+    }
+
+    @Path("/{catalogName}")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ResourceSecurity(PUBLIC)
+    public Response registerCatalog(@PathParam("catalogName") String catalogName, Map<String, String> catalogProperties)
+    {
+        dynamicCatalogStore.registerCatalog(catalogName, catalogProperties);
+        return Response.ok().build();
+    }
+
+    @Path("/{catalogName}")
+    @DELETE
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ResourceSecurity(PUBLIC)
+    public Response removeCatalog(@PathParam("catalogName") String catalogName)
+    {
+        dynamicCatalogStore.removeCatalog(catalogName);
+        return Response.ok().build();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/DynamicCatalogConfig.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DynamicCatalogConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.airlift.configuration.Config;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public class DynamicCatalogConfig
+{
+    private boolean enabled;
+    private int requestQueueCapacity = 200;
+    private long requestDispatchDelay = 5000;
+    private final TimeUnit requestDispatchTimeUnit = TimeUnit.MILLISECONDS;
+
+    @Config("experimental.dynamic-catalog.enable")
+    public DynamicCatalogConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @Config("experimental.dynamic-catalog.request-queue-capacity")
+    public DynamicCatalogConfig setRequestQueueCapacity(int requestQueueCapacity)
+    {
+        this.requestQueueCapacity = requestQueueCapacity;
+        return this;
+    }
+
+    @Config("experimental.dynamic-catalog.request-dispatch-delay")
+    public DynamicCatalogConfig setRequestDispatchDelay(String requestDispatchDuration)
+    {
+        final Duration duration = Duration.parse(requestDispatchDuration);
+        this.requestDispatchDelay = duration.toMillis();
+        return this;
+    }
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public int getRequestQueueCapacity()
+    {
+        return requestQueueCapacity;
+    }
+
+    public long getRequestDispatchDelay()
+    {
+        return requestDispatchDelay;
+    }
+
+    public TimeUnit getRequestDispatchTimeUnit()
+    {
+        return requestDispatchTimeUnit;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/DynamicCatalogStore.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DynamicCatalogStore.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.base.Splitter;
+import com.google.inject.Inject;
+import io.airlift.concurrent.Threads;
+import io.airlift.discovery.client.Announcer;
+import io.airlift.discovery.client.ServiceAnnouncement;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StatusResponseHandler;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.trino.connector.ConnectorManager;
+
+import javax.annotation.PreDestroy;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.Request.Builder.prepareDelete;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+
+public class DynamicCatalogStore
+{
+    private static final Logger log = Logger.get(DynamicCatalogStore.class);
+    private final ConnectorManager connectorManager;
+    private final InternalNodeManager nodeManager;
+    private final Announcer announcer;
+    private final HttpClient httpClient;
+    private final ScheduledExecutorService executor;
+    private final ArrayBlockingQueue<Function<InternalNode, Request>> dynamicCatalogRequestQueue;
+    private final File catalogConfigurationDir;
+
+    @Inject
+    public DynamicCatalogStore(ConnectorManager connectorManager, InternalNodeManager nodeManager, Announcer announcer,
+                               @ForNodeManager HttpClient httpClient,
+                               DynamicCatalogConfig dynamicCatalogConfig, StaticCatalogStoreConfig staticCatalogStoreConfig)
+    {
+        this.connectorManager = connectorManager;
+        this.nodeManager = nodeManager;
+        this.announcer = announcer;
+        this.httpClient = httpClient;
+        this.catalogConfigurationDir = staticCatalogStoreConfig.getCatalogConfigurationDir();
+        this.dynamicCatalogRequestQueue = new ArrayBlockingQueue<>(dynamicCatalogConfig.getRequestQueueCapacity(), true);
+        this.executor = new ScheduledThreadPoolExecutor(2, Threads.daemonThreadsNamed("Dispatcher-Catalog-%s"));
+        this.executor.schedule(() -> {
+            if (dynamicCatalogRequestQueue.isEmpty()) {
+                return;
+            }
+            try {
+                dispatchRequest(dynamicCatalogRequestQueue.poll(5, TimeUnit.SECONDS));
+            }
+            catch (InterruptedException ignored) {
+            }
+        }, dynamicCatalogConfig.getRequestDispatchDelay(), dynamicCatalogConfig.getRequestDispatchTimeUnit());
+    }
+
+    @PreDestroy
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void destroy()
+    {
+        this.executor.shutdownNow();
+        try {
+            this.executor.awaitTermination(30L, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException var2) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public List<String> catalogList()
+    {
+        final ServiceAnnouncement announcement = getTrinoAnnouncement();
+        final String propertyValue = announcement.getProperties().get("connectorIds");
+
+        if (propertyValue == null) {
+            return Collections.emptyList();
+        }
+
+        return Splitter.on(",").trimResults().omitEmptyStrings().splitToList(propertyValue);
+    }
+
+    public void registerCatalog(String catalogName, Map<String, String> catalogProperties)
+    {
+        checkArgument(catalogName != null, "catalog name must not be null.");
+        checkArgument(!catalogName.isBlank(), "catalog name must not be blank.");
+        checkArgument(catalogProperties != null, "properties must not be null.");
+        checkArgument(!catalogProperties.isEmpty(), "properties name must not be empty.");
+
+        final String connectorName = catalogProperties.remove("connector.name");
+        checkArgument(connectorName != null, "connector name must not be null.");
+        checkArgument(!connectorName.isBlank(), "connector name must not be blank.");
+
+        log.info("-- Loading catalog %s --", catalogName);
+        connectorManager.dropConnection(catalogName);
+        connectorManager.createCatalog(catalogName, connectorName, Map.copyOf(catalogProperties));
+        updateConnectorIds(catalogName, List::add);
+
+        dumpCatalogFile(catalogName, catalogProperties);
+        dumpCatalogRequest(uri -> preparePost()
+                .setUri(uri.resolve("/v1/catalog/" + catalogName))
+                .setHeader("Content-Type", "application/json; charset=utf8")
+                .setBodyGenerator(jsonBodyGenerator(JsonCodec.mapJsonCodec(String.class, String.class), catalogProperties))
+                .build());
+        log.info("-- Added catalog %s using connector %s --", catalogName, connectorName);
+    }
+
+    public void removeCatalog(String catalogName)
+    {
+        checkArgument(catalogName != null, "catalog name must not be null.");
+        checkArgument(!catalogName.isBlank(), "catalog name must not be blank.");
+
+        log.info("-- Removing catalog %s --", catalogName);
+        connectorManager.dropConnection(catalogName);
+        updateConnectorIds(catalogName, List::remove);
+
+        rmCatalogFile(catalogName);
+
+        dumpCatalogRequest(uri -> prepareDelete()
+                .setUri(uri.resolve("/v1/catalog/" + catalogName))
+                .setHeader("Content-Type", "application/json; charset=utf8")
+                .build());
+        log.info("-- Removed catalog %s --", catalogName);
+    }
+
+    void dispatchRequest(Function<InternalNode, Request> nodeRequestFunction)
+    {
+        final Set<InternalNode> activeNodes = nodeManager.getNodes(NodeState.ACTIVE);
+        int dispatchCount = 0;
+        for (InternalNode activeNode : activeNodes) {
+            if (activeNode.isCoordinator()) {
+                continue;
+            }
+            final Request request = nodeRequestFunction.apply(activeNode);
+            StatusResponseHandler.StatusResponse response = httpClient.execute(request, createStatusResponseHandler());
+            if (response.getStatusCode() != 200) {
+                log.warn("-- Dispatch catalog resource request %s --", activeNode);
+                continue;
+            }
+            dispatchCount++;
+        }
+        if (dispatchCount == 0) {
+            log.warn("Dispatch failed, no worker was received.");
+            dynamicCatalogRequestQueue.offer(nodeRequestFunction);
+        }
+    }
+
+    void dumpCatalogRequest(Function<URI, Request> requestFunc)
+    {
+        Function<InternalNode, URI> nodeURIFunction = InternalNode::getInternalUri;
+        dynamicCatalogRequestQueue.offer(nodeURIFunction.andThen(requestFunc));
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    void rmCatalogFile(String catalogName)
+    {
+        new File(catalogConfigurationDir, catalogName + ".properties").delete();
+    }
+
+    void dumpCatalogFile(String catalogName, Map<String, String> catalogProperties)
+    {
+        final Properties properties = new Properties();
+        properties.putAll(catalogProperties);
+        final Path propertiesPath = catalogConfigurationDir.toPath().resolve(catalogName + ".properties");
+        try (OutputStream os = Files.newOutputStream(propertiesPath)) {
+            properties.store(os, null);
+        }
+        catch (IOException e) {
+            log.error("Dump catalog properties error", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    void updateConnectorIds(String catalogName, BiConsumer<List<String>, String> accumulator)
+    {
+        final ServiceAnnouncement announcement = getTrinoAnnouncement();
+        final Map<String, String> properties = new LinkedHashMap<>(announcement.getProperties());
+        final String propertyValue = announcement.getProperties().get("connectorIds");
+
+        final List<String> connectorIds = propertyValue == null ? new ArrayList<>(1) :
+                Splitter.on(",").trimResults().omitEmptyStrings().splitToList(propertyValue);
+        accumulator.accept(connectorIds, catalogName);
+        properties.put("connectorIds", String.join(",", connectorIds));
+
+        announcer.removeServiceAnnouncement(announcement.getId());
+        announcer.addServiceAnnouncement(serviceAnnouncement(announcement.getType()).addProperties(properties).build());
+        announcer.forceAnnounce();
+
+        nodeManager.refreshNodes();
+    }
+
+    ServiceAnnouncement getTrinoAnnouncement()
+    {
+        final Set<ServiceAnnouncement> announcements = announcer.getServiceAnnouncements();
+        for (ServiceAnnouncement serviceAnnouncement : announcer.getServiceAnnouncements()) {
+            if ("trino".equals(serviceAnnouncement.getType())) {
+                return serviceAnnouncement;
+            }
+        }
+        throw new IllegalArgumentException("Trino announcement not found: " + announcements);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/DynamicCatalogStore.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DynamicCatalogStore.java
@@ -200,7 +200,7 @@ public class DynamicCatalogStore
             properties.store(os, null);
         }
         catch (IOException e) {
-            log.error("Dump catalog properties error", e);
+            log.error("Dump catalog properties error.");
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -65,8 +65,11 @@ import io.trino.memory.MemoryResource;
 import io.trino.memory.NodeMemoryConfig;
 import io.trino.metadata.BlockEncodingManager;
 import io.trino.metadata.CatalogManager;
+import io.trino.metadata.CatalogResource;
 import io.trino.metadata.DisabledSystemSecurityMetadata;
 import io.trino.metadata.DiscoveryNodeManager;
+import io.trino.metadata.DynamicCatalogConfig;
+import io.trino.metadata.DynamicCatalogStore;
 import io.trino.metadata.ForNodeManager;
 import io.trino.metadata.FunctionBundle;
 import io.trino.metadata.FunctionManager;
@@ -353,6 +356,12 @@ public class ServerMainModule
         binder.bind(PageSinkProvider.class).to(PageSinkManager.class).in(Scopes.SINGLETON);
 
         // metadata
+        DynamicCatalogConfig dynamicCatalogConfig = buildConfigObject(DynamicCatalogConfig.class);
+        if (dynamicCatalogConfig.isEnabled()) {
+            binder.bind(DynamicCatalogStore.class).in(Scopes.SINGLETON);
+            jaxrsBinder(binder).bind(CatalogResource.class);
+        }
+
         binder.bind(StaticCatalogStore.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(StaticCatalogStoreConfig.class);
         binder.bind(MetadataManager.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/test/java/io/trino/metadata/TestCatalogResource.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestCatalogResource.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StatusResponseHandler;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.json.JsonCodec;
+import io.trino.server.testing.TestingTrinoServer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.prepareDelete;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.testing.Closeables.closeAll;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestCatalogResource
+{
+    private HttpClient client;
+    private TestingTrinoServer server;
+
+    @BeforeMethod
+    public void setup()
+    {
+        client = new JettyHttpClient();
+        server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("experimental.dynamic-catalog.enable", "true")
+                        .put("catalog.config-dir", requireNonNull(TestCatalogResource.class.getResource(".")).getFile())
+                        .buildOrThrow())
+                .build();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown() throws Exception
+    {
+        closeAll(server, client);
+    }
+
+    @Test
+    public void testRegisterCatalog()
+    {
+        String catalogName = "test";
+        Request request = preparePost().setUri(server.getBaseUrl().resolve("/v1/catalog/" + catalogName))
+                .setHeader("content-type", "application/json")
+                .setBodyGenerator(jsonBodyGenerator(JsonCodec.mapJsonCodec(String.class, String.class), Map.of(
+                        "connector.name", "system",
+                        "connection-url", "jdbc:postgresql://localhost:5432/postgres",
+                        "connection-user", "postgres",
+                        "connection-password", "postgres")))
+                .build();
+
+        StatusResponseHandler.StatusResponse response = client.execute(request, createStatusResponseHandler());
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test(priority = 2)
+    public void testEditCatalog()
+    {
+        String catalogName = "test";
+        Request request = preparePost().setUri(server.getBaseUrl().resolve("/v1/catalog/" + catalogName))
+                .setHeader("content-type", "application/json")
+                .setBodyGenerator(jsonBodyGenerator(JsonCodec.mapJsonCodec(String.class, String.class), Map.of(
+                        "connector.name", "system",
+                        "connection-url", "jdbc:postgresql://localhost:5432/postgres",
+                        "connection-user", "postgres",
+                        "connection-password", "modified")))
+                .build();
+
+        StatusResponseHandler.StatusResponse response = client.execute(request, createStatusResponseHandler());
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test(priority = 3)
+    public void testDeleteCatalog()
+    {
+        String catalogName = "test";
+        Request request = prepareDelete().setUri(server.getBaseUrl().resolve("/v1/catalog/" + catalogName)).build();
+
+        StatusResponseHandler.StatusResponse response = client.execute(request, createStatusResponseHandler());
+        assertEquals(response.getStatusCode(), 200);
+    }
+
+    @Test
+    public void catalogList()
+    {
+        Request request = prepareGet().setUri(server.getBaseUrl().resolve("/v1/catalog")).build();
+
+        List<String> catalogList = client.execute(request, createJsonResponseHandler(JsonCodec.listJsonCodec(String.class)));
+        assertTrue(catalogList.isEmpty());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/metadata/TestDynamicCatalogStore.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestDynamicCatalogStore.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Key;
+import io.airlift.json.JsonCodec;
+import io.trino.client.NodeVersion;
+import io.trino.connector.CatalogName;
+import io.trino.server.testing.TestingTrinoServer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.Request.Builder.prepareDelete;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.testing.assertions.Assert.assertEquals;
+import static java.util.Objects.requireNonNull;
+
+@Test(singleThreaded = true)
+public class TestDynamicCatalogStore
+{
+    private static final CatalogName CONNECTOR_ID = new CatalogName("connector_id");
+    private static final Map<String, String> DYNAMIC_CATALOG_PROPERTIES = ImmutableMap.<String, String>builder()
+            .put("experimental.dynamic-catalog.enable", "true")
+            .put("catalog.config-dir", requireNonNull(TestCatalogResource.class.getResource(".")).getFile())
+            .buildOrThrow();
+
+    private InMemoryNodeManager nodeManager;
+    private DynamicCatalogStore dynamicCatalogStore;
+    private TestingTrinoServer server;
+    private TestingTrinoServer worker;
+
+    @BeforeMethod
+    public void setUp() throws NoSuchFieldException, IllegalAccessException
+    {
+        this.nodeManager = new InMemoryNodeManager();
+        this.server = TestingTrinoServer.builder().setProperties(DYNAMIC_CATALOG_PROPERTIES).build();
+        this.worker = TestingTrinoServer.builder().setCoordinator(false).setProperties(DYNAMIC_CATALOG_PROPERTIES).build();
+        this.dynamicCatalogStore = server.getInstance(Key.get(DynamicCatalogStore.class));
+        setUpWorkerNode(worker);
+    }
+
+    private void setUpWorkerNode(TestingTrinoServer worker) throws NoSuchFieldException, IllegalAccessException
+    {
+        com.google.common.collect.ImmutableList.Builder<InternalNode> nodeBuilder = com.google.common.collect.ImmutableList.builder();
+        nodeBuilder.add(new InternalNode("worker", worker.getBaseUrl(), NodeVersion.UNKNOWN, false));
+        com.google.common.collect.ImmutableList<InternalNode> nodes = nodeBuilder.build();
+        nodeManager.addNode(CONNECTOR_ID, nodes);
+
+        Field nodeManagerField = DynamicCatalogStore.class.getDeclaredField("nodeManager");
+        nodeManagerField.setAccessible(true);
+        nodeManagerField.set(dynamicCatalogStore, nodeManager);
+    }
+
+    @Test
+    public void dispatchRegisterCatalogRequest()
+    {
+        dynamicCatalogStore.dispatchRequest(node -> {
+            URI uri = node.getInternalUri();
+            return preparePost()
+                    .setUri(uri.resolve("/v1/catalog/test"))
+                    .setHeader("Content-Type", "application/json; charset=utf8")
+                    .setBodyGenerator(jsonBodyGenerator(JsonCodec.mapJsonCodec(String.class, String.class), Map.of(
+                            "connector.name", "system",
+                            "connection-url", "jdbc:postgresql://localhost:5432/postgres",
+                            "connection-user", "postgres",
+                            "connection-password", "postgres")))
+                    .build();
+        });
+
+        DynamicCatalogStore workerCatalogStore = worker.getInstance(Key.get(DynamicCatalogStore.class));
+        List<String> workerCatalogList = workerCatalogStore.catalogList();
+        assertEquals(workerCatalogList.size(), 1);
+        assertEquals(workerCatalogList.get(0), "test");
+    }
+
+    @Test(priority = 2)
+    public void dispatchDeleteCatalogRequest()
+    {
+        dynamicCatalogStore.dispatchRequest(node -> {
+            URI uri = node.getInternalUri();
+            return prepareDelete().setUri(uri.resolve("/v1/catalog/test")).build();
+        });
+
+        DynamicCatalogStore workerCatalogStore = worker.getInstance(Key.get(DynamicCatalogStore.class));
+        List<String> workerCatalogList = workerCatalogStore.catalogList();
+        assertEquals(workerCatalogList.size(), 0);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown() throws Exception
+    {
+        closeAll(server);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/metadata/TestDynamicCatalogStoreConfig.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestDynamicCatalogStoreConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestDynamicCatalogStoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(DynamicCatalogConfig.class)
+                .setRequestDispatchDelay(Duration.of(5000, ChronoUnit.MILLIS).toString())
+                .setRequestQueueCapacity(200)
+                .setEnabled(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("experimental.dynamic-catalog.enable", "true")
+                .put("experimental.dynamic-catalog.request-queue-capacity", "400")
+                .put("experimental.dynamic-catalog.request-dispatch-delay", "PT10S")
+                .buildOrThrow();
+
+        DynamicCatalogConfig expected = new DynamicCatalogConfig()
+                .setRequestQueueCapacity(400)
+                .setRequestDispatchDelay("PT10S")
+                .setEnabled(true);
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->

## Description
This PR adds support for CREATE and DROP catalog statements using the new dynamic catalog system. This PR includes:

- Support for starting server with `experimental.dynamic-catalog.enable` config to turn it feature on,
more details see `DynamicCatalogConfig`.

- Support for CREATE/DROP persistently in DynamicCatalogStore.
It will sync catalog CREATE/DROP request on active worker nodes, so it does not need reboot the workers if occured `No avaiable node to query`.
- Support for CREATE/DROP/LIST HTTP entryPoint in CatalogResource.

## Related issues, pull requests, and links
- #1

<!-- List any issues fixed by this PR, and provide links to other related PRs, upstream release notes, and other useful resources. For example:
* Fixes #issuenumber
* Related documentation in #issuenumber
* [Some release notes](http://usefulinfo.example.com)
-->

<!-- The following sections are filled in by the maintainer with input from the contributor:
Use :white_check_mark: or (x) to signal selection.
-->

## Documentation

( ) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

( ) No release notes entries required.
( ) Release notes entries required with the following suggested text:
